### PR TITLE
Add RSAT Feature on dc.join to support Win10 OS

### DIFF
--- a/vagrant-uplift/lib/scripts/vagrant/uplift.vagrant.dcjoin/dc.join.dsc.ps1
+++ b/vagrant-uplift/lib/scripts/vagrant/uplift.vagrant.dcjoin/dc.join.dsc.ps1
@@ -21,7 +21,108 @@ $domainJoinUserCreds = New-Object System.Management.Automation.PSCredential($dom
 
 # helpers
 Write-UpliftMessage "Importing ActiveDirectory module..."
-Import-Module ActiveDirectory
+
+Function Install-ADModule {
+    [CmdletBinding()]
+    Param(
+        [switch]$Test = $false
+    )
+    
+    If ((Get-CimInstance Win32_OperatingSystem).Caption -like "*Server*") {
+        Write-UpliftMessage 'This system is running Windows Server'
+
+    }else{
+        If ((Get-CimInstance Win32_OperatingSystem).Caption -like "*Windows 10*") {
+            Write-UpliftMessage 'This system is running Windows 10'
+        } Else {
+            Write-UpliftMessage 'This system is not running Windows 10 nor Server'
+            Write-UpliftMessage 'Trying to install RSAT using choco'
+            choco install -y rsat.featurepack --limit-output --acceptlicense --no-progress;
+            Confirm-UpliftExitCode $LASTEXITCODE "Cannot install rsat.featurepack"
+        }
+    }
+    
+
+    If ((Get-HotFix -Id KB2693643 -ErrorAction SilentlyContinue) -or ([System.Environment]::OsVersion.Version.Build -ge 18362)) {
+
+        Write-UpliftMessage 'RSAT for Windows 10 is already installed'
+
+    } Else {
+
+        Write-UpliftMessage 'Downloading RSAT for Windows 10'
+
+        If ((Get-CimInstance Win32_ComputerSystem).SystemType -like "x64*") {
+            $dl = 'WindowsTH-KB2693643-x64.msu'
+        } Else {
+            $dl = 'WindowsTH-KB2693643-x86.msu'
+        }
+        Write-UpliftMessage "Hotfix file is $dl"
+
+        Write-UpliftMessage "$(Get-Date)"
+        #Download file sample
+        #https://gallery.technet.microsoft.com/scriptcenter/files-from-websites-4a181ff3
+        $BaseURL = 'https://download.microsoft.com/download/1/D/8/1D8B5022-5477-4B9A-8104-6A71FF9D98AB/'
+        $URL = $BaseURL + $dl
+        $Destination = Join-Path -Path $HOME -ChildPath "Downloads\$dl"
+        $WebClient = New-Object System.Net.WebClient
+        $WebClient.DownloadFile($URL,$Destination)
+        $WebClient.Dispose()
+
+        Write-UpliftMessage 'Installing RSAT for Windows 10'
+        Write-UpliftMessage "$(Get-Date)"
+        # http://stackoverflow.com/questions/21112244/apply-service-packs-msu-file-update-using-powershell-scripts-on-local-server
+        wusa.exe $Destination /quiet /norestart /log:$home\Documents\RSAT.log
+
+        # wusa.exe returns immediately. Loop until install complete.
+        do {
+            Write-UpliftMessage "." -NoNewline
+            Start-Sleep -Seconds 3
+        } until (Get-HotFix -Id KB2693643 -ErrorAction SilentlyContinue)
+        Write-UpliftMessage "."
+        Write-UpliftMessage "$(Get-Date)"
+    }
+
+    # The latest versions of the RSAT automatically enable all RSAT features
+    If ((Get-WindowsOptionalFeature -Online -FeatureName `
+        RSATClient-Roles-AD-Powershell -ErrorAction SilentlyContinue).State `
+        -eq 'Enabled') {
+
+        Write-UpliftMessage 'RSAT AD PowerShell already enabled'
+
+    } Else {
+
+        Write-UpliftMessage 'Enabling RSAT AD PowerShell'
+
+        if ([System.Environment]::OsVersion.Version.Build -ge 18362) {
+            Get-WindowsCapability -Online |
+                Where-Object Name -Match 'Rsat.ActiveDirectory'|
+                    ForEach-Object -Process {Add-WindowsCapability -Online -Name $PSItem.Name}
+        }else{
+            Enable-WindowsOptionalFeature -Online -FeatureName RSATClient-Roles-AD-Powershell
+        }
+        
+
+    }
+
+
+    Write-UpliftMessage 'ActiveDirectory PowerShell module install complete'
+    Write-UpliftMessage 'Importing ActiveDirectory module'
+    Import-Module ActiveDirectory
+    
+    # Verify
+    If ($Test) {
+        Write-UpliftMessage 'Validating AD PowerShell install'
+        if (Get-Module -ListAvailable | Where-Object {$_.Name -eq 'ActiveDirectory'}){
+            Write-UpliftMessage 'Success AD PowerShell installed'
+        }else{
+            Write-UpliftMessage 'Failed AD PowerShell did not install'
+        }
+        
+    }
+}
+
+Install-ADModule -Test
+
 
 function Helper-RemoveADComputer
 {


### PR DESCRIPTION
DC.JOIN uplift script requires "Import-Module ActiveDirectory" which does not exist in certain Windows. This fork add the RSAT feature in order to support OS'es other than the default Win Server2016.
@SubPointSupport 
http://woshub.com/install-rsat-feature-windows-10-powershell/
https://theitbros.com/install-and-import-powershell-active-directory-module/